### PR TITLE
feat(css): build taildwind after msbuild build phase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+indent_size = 4
+tab_width = 4
+indent_style = tab
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+
+[*.{md,json,csproj,targets}]
+indent_size = 2
+indent_style = space

--- a/SmartOrder.csproj
+++ b/SmartOrder.csproj
@@ -10,11 +10,6 @@
     <NoWarn>$(NoWarn);NETSDK1057</NoWarn>
   </PropertyGroup>
 
-
-  <ItemGroup>
-    <Watch Include="./Styles/**/*.css" />
-  </ItemGroup>
-
   <!-- Third Party Dependencies -->
   <ItemGroup>
     <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.4.1" />
@@ -35,7 +30,7 @@
       <HintPath>lib/SMART.Utility.Globalization.dll</HintPath>
     </Reference>
   </ItemGroup>
-  
+
   <!-- Internal Dependencies -->
   <ItemGroup Condition="'$(Configuration)'!='Release'">
     <ProjectReference Include="../daemon-dotnet/DataAccess/DataAccess.csproj" />
@@ -46,59 +41,94 @@
     <PackageReference Include="SmartOrderApi" Version="1.*-*" />
   </ItemGroup>
 
+  <!--
+    Use local node_modules binaries if they exist.
+
+    If there is another directory, say in the CI/CD environment, that tailwindcss
+    is stored, then we should add another <Exec> to this block with the condition
+    that it only run when `'$(CI)' == 'true'`.  That will ensure that this can find
+    the bin anytime
+   -->
+  <Target Name="UseLocalNodeModules" Condition="Exists('node_modules/.bin')">
+    <Exec Command="export PATH=&quot;$(MSBuildProjectDirectory)/node_modules/.bin:$PATH&quot;"  />
+  </Target>
 
   <!-- Integrate TailwindCSS -->
-  <PropertyGroup Condition="$(CI) != 'true'">
+  <ItemGroup>
+    <!--
+      This gives us a list of files we can process in a loop later
+      Ultimately, we get an `IItemList[]` collection of files that are
+      found under `./Styles` with a `.css` extension.  For each item in the list, a
+      property, `OutputPath`, will be attached, using `RecursiveDir` to maintain the
+      directory structure that was found below `./Styles`
+    -->
+    <CssStyles Include="./Styles/**/*.css">
+      <!-- %(RecursiveDir): The directory traversed during wildcard expansion -->
+      <!-- The other two are probably self-explanatory -->
+      <OutputPath>./wwwroot/css/%(RecursiveDir)%(Filename)%(Extension)</OutputPath>
+    </CssStyles>
+  </ItemGroup>
+
+  <PropertyGroup>
     <TailwindCssPath>/usr/local/bin/tailwindcss</TailwindCssPath>
   </PropertyGroup>
-  <Target Name="FindTailwindCss">
+
+  <Target Name="FindTailwindCss" DependsOnTargets="UseLocalNodeModules">
       <Exec Command="where tailwindcss" ConsoleToMSBuild="true" Condition="'$(OS)' == 'Windows_NT'">
-          <Output TaskParameter="ConsoleOutput" PropertyName="TailwindCssPath" />
+        <Output TaskParameter="ConsoleOutput" PropertyName="TailwindCssPath" />
       </Exec>
       <Exec Command="command -v tailwindcss" ConsoleToMSBuild="true" Condition="'$(OS)' != 'Windows_NT'">
-          <Output TaskParameter="ConsoleOutput" PropertyName="TailwindCssPath" />
+        <Output TaskParameter="ConsoleOutput" PropertyName="TailwindCssPath" />
       </Exec>
   </Target>
+
   <Target
-    Name="ProcessScopedCssFilesWithTailwind" 
+    Name="ProcessScopedCssFilesWithTailwind"
     AfterTargets="_GenerateScopedCssFiles"
   >
-    <MSBuild 
-      Projects="$(MSBuildProjectFile)" 
-      Properties="CurrentScopedCssFile=%(_ScopedCssOutputs.Identity)" 
+    <MSBuild
+      Projects="$(MSBuildProjectFile)"
+      Properties="CurrentScopedCssFile=%(_ScopedCssOutputs.Identity)"
       Targets="ProcessScopedCssFileWithTailwind"
     >
     </MSBuild>
   </Target>
 
-  <Target Name="ProcessScopedCssFileWithTailwind">
-    <Message 
-      Importance="high" 
-      Text="Processing with Tailwind: $(CurrentScopedCssFile)" 
+  <Target
+    Name="ProcessScopedCssFileWithTailwind"
+    DependsOnTargets="FindTailwindCss"
+  >
+    <Message
+      Importance="high"
+      Text="Processing with Tailwind: $(CurrentScopedCssFile)"
     />
-    <Exec 
-      Command="$(TAILWINDCSS_PATH) -i $(CurrentScopedCssFile) -o $(CurrentScopedCssFile)" 
-      WorkingDirectory="$(MSBuildProjectDirectory)" 
+    <Exec
+      Command="$(TailwindCssPath) -i $(CurrentScopedCssfile) -o $(CurrentScopedCssFile)"
+      WorkingDirectory="$(MSBuildProjectDirectory)"
     />
   </Target>
-  
+
   <!-- Normal build process -->
   <Target
     Name="Build TailwindCss"
     BeforeTargets="PreBuildEvent"
     DependsOnTargets="FindTailwindCss"
-    Condition="'$(DotNetWatchBuild)' != 'true'"
+    Inputs="@(CssStyles)"
+    Outputs="%(CssStyles.OutputPath)"
   >
-    <Exec Command="$(TailwindCssPath) build -i ./Styles/site.css -o ./wwwroot/css/site.css" />
+    <Exec
+      Command="$(TailwindCssPath) build -i %(CssStyles.Identity) -o %(CssStyles.OutputPath)"
+      WorkingDirectory="$(MSBuildProjectDirectory)"
+    />
   </Target>
-  
+
   <!-- run tailwindcss watch process by using `dotnet watch run` (or just `dotnet watch`)-->
-  <Target
+  <!-- <Target
     Name="Watch TailwindCss"
     BeforeTargets="PreBuildEvent"
     DependsOnTargets="FindTailwindCss"
     Condition="'$(DotNetWatchBuild)' == 'true'"
   >
-    <Exec Command="$(TailwindCssPath) build -i ./Styles/site.css -o ./wwwroot/css/site.css --watch" />
-  </Target>
+    <Exec Command="$(TailwindCssPath) build -i ./Styles/site.css -o ./wwwroot/css/site.css -w" />
+  </Target> -->
 </Project>

--- a/SmartOrder.csproj
+++ b/SmartOrder.csproj
@@ -10,9 +10,6 @@
     <NoWarn>$(NoWarn);NETSDK1057</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(CI) != 'true'">
-    <TAILWINDCSS_PATH>/usr/local/bin/tailwindcss</TAILWINDCSS_PATH>
-  </PropertyGroup>
 
   <ItemGroup>
     <Watch Include="./Styles/**/*.css" />
@@ -51,7 +48,17 @@
 
 
   <!-- Integrate TailwindCSS -->
-
+  <PropertyGroup Condition="$(CI) != 'true'">
+    <TailwindCssPath>/usr/local/bin/tailwindcss</TailwindCssPath>
+  </PropertyGroup>
+  <Target Name="FindTailwindCss">
+      <Exec Command="where tailwindcss" ConsoleToMSBuild="true" Condition="'$(OS)' == 'Windows_NT'">
+          <Output TaskParameter="ConsoleOutput" PropertyName="TailwindCssPath" />
+      </Exec>
+      <Exec Command="command -v tailwindcss" ConsoleToMSBuild="true" Condition="'$(OS)' != 'Windows_NT'">
+          <Output TaskParameter="ConsoleOutput" PropertyName="TailwindCssPath" />
+      </Exec>
+  </Target>
   <Target
     Name="ProcessScopedCssFilesWithTailwind" 
     AfterTargets="_GenerateScopedCssFiles"
@@ -74,13 +81,24 @@
       WorkingDirectory="$(MSBuildProjectDirectory)" 
     />
   </Target>
-
+  
+  <!-- Normal build process -->
   <Target
-    Name="Build TailwindCSS" 
-    AfterTargets="Build"
+    Name="Build TailwindCss"
+    BeforeTargets="PreBuildEvent"
+    DependsOnTargets="FindTailwindCss"
+    Condition="'$(DotNetWatchBuild)' != 'true'"
   >
-    <Exec 
-      Command="$(ProjectDir)build-tailwind.sh" 
-    />
+    <Exec Command="$(TailwindCssPath) build -i ./Styles/site.css -o ./wwwroot/css/site.css" />
+  </Target>
+  
+  <!-- run tailwindcss watch process by using `dotnet watch run` (or just `dotnet watch`)-->
+  <Target
+    Name="Watch TailwindCss"
+    BeforeTargets="PreBuildEvent"
+    DependsOnTargets="FindTailwindCss"
+    Condition="'$(DotNetWatchBuild)' == 'true'"
+  >
+    <Exec Command="$(TailwindCssPath) build -i ./Styles/site.css -o ./wwwroot/css/site.css --watch" />
   </Target>
 </Project>


### PR DESCRIPTION
## Description

Incorporates a couple of changes to the `.csproj` to allow for running `tailwindcss` with the `--watch` property.  Namely:

* It adds a new `<Target>` directive that only runs when the `DotNetWatch` is true
* Uses a context aware (read: operating system) `<Target>` that locates the `tailwindcss` binary

---

Additional information::

Original work was actually in the `daemon-dotnet` repo.  You can see that work [here](https://github.com/daemontechtools/daemon-dotnet/compare/main...feature/build-tasks-tailwindcss).  It's worth noting that the approach that I was following there, implementing custom tasks into MSBuild, is much more scalable/flexible, but is entirely too much for this work task.

The branch is obviously a WIP, and there's maybe another day's worth of work in testing and wiring, but we can delete it at will.  However, if any more functionality is needed in the tailwindcss department, I would suggest going that route.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules